### PR TITLE
feat: tar package modifiers input, allowing additional excludes when packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ unknown docker-images. It is entirely built from Dockerfile on top of
    container will have this prefix in name.
  * `docker_compose_filename` - Path to the docker-compose file in the repository.
  * `use_stack` - Use docker stack instead of docker-compose.
+ * `tar_package_operation_modifiers` - Modifiers for tar package operation. Default is '--exclude .git --exclude .github'
 
 # Usage example
 
@@ -112,7 +113,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - actions/chockout@v2
+    - actions/checkout@v2
 
     - uses: alex-ac/github-action-ssh-docker-compose@master
       name: Docker-Stack Remote Deployment

--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,9 @@ inputs:
   use_stack:
     description: Use docker stack instead of docker compose ("true" or "false").
     default: 'false'
+  tar_package_operation_modifiers:
+    description: Tar operation modifiers used while creating the package.
+    default: '--exclude .git --exclude .github --exclude .gitignore --exclude .gitmodules --exclude .vscode'
 runs:
   using: docker
   image: Dockerfile
@@ -34,3 +37,4 @@ runs:
     DOCKER_COMPOSE_FILENAME: ${{ inputs.docker_compose_filename }}
     DOCKER_COMPOSE_PREFIX: ${{ inputs.docker_compose_prefix }}
     USE_DOCKER_STACK: ${{ inputs.use_stack }}
+    TAR_PACKAGE_OPERATION_MODIFIERS: ${{ inputs.tar_package_operation_modifiers }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,7 +15,7 @@ cleanup() {
 trap cleanup EXIT
 
 log "Packing workspace into archive to transfer onto remote machine."
-tar cjvf /tmp/workspace.tar.bz2 --exclude .git .
+tar cjvf /tmp/workspace.tar.bz2 $TAR_PACKAGE_OPERATION_MODIFIERS .
 
 log "Launching ssh agent."
 eval `ssh-agent -s`


### PR DESCRIPTION
Added additional input to allow the customization of excludes when packaging the tar. This is useful to exclude other folders like .github, .vscode, or any other from the packaging to destination, reducing tar size and increasing flexibility.